### PR TITLE
Refactor Runnable with name, formatter, and hooks

### DIFF
--- a/lib/mars/aggregator.rb
+++ b/lib/mars/aggregator.rb
@@ -2,12 +2,11 @@
 
 module MARS
   class Aggregator < Runnable
-    attr_reader :name, :operation
+    attr_reader :operation
 
     def initialize(name = "Aggregator", operation: nil, **kwargs)
-      super(**kwargs)
+      super(name: name, **kwargs)
 
-      @name = name
       @operation = operation || ->(inputs) { inputs }
     end
 

--- a/lib/mars/gate.rb
+++ b/lib/mars/gate.rb
@@ -2,12 +2,9 @@
 
 module MARS
   class Gate < Runnable
-    attr_reader :name
-
     def initialize(name = "Gate", condition:, branches:, **kwargs)
-      super(**kwargs)
+      super(name: name, **kwargs)
 
-      @name = name
       @condition = condition
       @branches = branches
     end

--- a/lib/mars/runnable.rb
+++ b/lib/mars/runnable.rb
@@ -2,10 +2,28 @@
 
 module MARS
   class Runnable
+    include Hooks
+
+    attr_reader :name, :formatter
     attr_accessor :state
 
-    def initialize(state: {})
+    class << self
+      def step_name
+        return @step_name if defined?(@step_name)
+        return unless name
+
+        name.split("::").last.gsub(/([a-z])([A-Z])/, '\1_\2').downcase
+      end
+
+      def formatter(klass = nil)
+        klass ? @formatter_class = klass : @formatter_class
+      end
+    end
+
+    def initialize(name: self.class.step_name, state: {}, formatter: nil)
+      @name = name
       @state = state
+      @formatter = formatter || self.class.formatter&.new || Formatter.new
     end
 
     def run(input)

--- a/lib/mars/workflows/parallel.rb
+++ b/lib/mars/workflows/parallel.rb
@@ -3,12 +3,9 @@
 module MARS
   module Workflows
     class Parallel < Runnable
-      attr_reader :name
-
       def initialize(name, steps:, aggregator: nil, **kwargs)
-        super(**kwargs)
+        super(name: name, **kwargs)
 
-        @name = name
         @steps = steps
         @aggregator = aggregator || Aggregator.new("#{name} Aggregator")
       end

--- a/lib/mars/workflows/sequential.rb
+++ b/lib/mars/workflows/sequential.rb
@@ -3,12 +3,9 @@
 module MARS
   module Workflows
     class Sequential < Runnable
-      attr_reader :name
-
       def initialize(name, steps:, **kwargs)
-        super(**kwargs)
+        super(name: name, **kwargs)
 
-        @name = name
         @steps = steps
       end
 

--- a/spec/mars/runnable_spec.rb
+++ b/spec/mars/runnable_spec.rb
@@ -42,6 +42,73 @@ RSpec.describe MARS::Runnable do
     end
   end
 
+  describe "#name" do
+    it "defaults to nil for anonymous classes" do
+      klass = Class.new(described_class)
+      expect(klass.new.name).to be_nil
+    end
+
+    it "can be set via the name keyword" do
+      runnable = described_class.new(name: "my_step")
+      expect(runnable.name).to eq("my_step")
+    end
+
+    it "derives step_name from the class name" do
+      stub_const("MARS::MyCustomStep", Class.new(described_class))
+      expect(MARS::MyCustomStep.new.name).to eq("my_custom_step")
+    end
+  end
+
+  describe "#formatter" do
+    it "defaults to a Formatter instance" do
+      runnable = described_class.new
+      expect(runnable.formatter).to be_a(MARS::Formatter)
+    end
+
+    it "can be set via the formatter keyword" do
+      custom_formatter = MARS::Formatter.new
+      runnable = described_class.new(formatter: custom_formatter)
+      expect(runnable.formatter).to eq(custom_formatter)
+    end
+
+    it "uses the class-level formatter when declared" do
+      custom_formatter_class = Class.new(MARS::Formatter)
+      klass = Class.new(described_class) do
+        formatter custom_formatter_class
+      end
+
+      expect(klass.new.formatter).to be_a(custom_formatter_class)
+    end
+  end
+
+  describe "hooks" do
+    it "includes Hooks module" do
+      expect(described_class.ancestors).to include(MARS::Hooks)
+    end
+
+    it "supports before_run hooks" do
+      klass = Class.new(described_class)
+      calls = []
+      klass.before_run { |_ctx, step| calls << step.name }
+
+      step = klass.new(name: "test")
+      step.run_before_hooks(MARS::ExecutionContext.new(input: "x"))
+
+      expect(calls).to eq(["test"])
+    end
+
+    it "supports after_run hooks" do
+      klass = Class.new(described_class)
+      calls = []
+      klass.after_run { |_ctx, result, _step| calls << result }
+
+      step = klass.new(name: "test")
+      step.run_after_hooks(MARS::ExecutionContext.new(input: "x"), "result")
+
+      expect(calls).to eq(["result"])
+    end
+  end
+
   describe "inheritance" do
     it "can be inherited" do
       subclass = Class.new(described_class)


### PR DESCRIPTION
## Summary
- **Runnable** now includes `Hooks`, has a `name` attribute (auto-derived from class name via `step_name`), and a `formatter` class-level DSL with instance-level override
- **Gate, Aggregator, Sequential, Parallel** delegate `name` to Runnable's constructor instead of managing their own `attr_reader :name`
- Expanded Runnable spec covering name derivation, formatter DSL, and hooks integration

Phase 2 of the v2 refactor. Depends on #24 (ExecutionContext, Formatter, Hooks).

## Test plan
- [x] Name defaults to nil for anonymous classes, auto-derives for named classes (e.g. `MyCustomStep` → `my_custom_step`)
- [x] Formatter defaults to `Mars::Formatter`, respects class-level DSL and instance override
- [x] Hooks module mixed in — `before_run`/`after_run` work on any Runnable
- [x] All existing Gate, Aggregator, Sequential, Parallel specs still pass
- [x] 62 specs total, 0 failures
- [x] Rubocop clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)