### PR TITLE
Gate guard model with halt scopes

### DIFF
--- a/README.md
+++ b/README.md
@@ -120,16 +120,26 @@ parallel = MARS::Workflows::Parallel.new(
 
 ### Gates
 
-Create conditional branching in your workflows:
+Gates act as guards that either let the workflow continue or divert to a fallback path:
 
 ```ruby
 gate = MARS::Gate.new(
-  "Decision Gate",
-  condition: ->(input) { input[:score] > 0.5 ? :success : :failure },
-  branches: {
-    success: success_workflow,
+  "Validation Gate",
+  check: ->(input) { :failure unless input[:score] > 0.5 },
+  fallbacks: {
     failure: failure_workflow
   }
+)
+```
+
+Control halt scope — `:local` (default) stops only the parent workflow, `:global` propagates to the root:
+
+```ruby
+gate = MARS::Gate.new(
+  "Critical Gate",
+  check: ->(input) { :error unless input[:valid] },
+  fallbacks: { error: error_workflow },
+  halt_scope: :global
 )
 ```
 

--- a/examples/complex_llm_workflow/generator.rb
+++ b/examples/complex_llm_workflow/generator.rb
@@ -91,8 +91,8 @@ error_workflow = MARS::Workflows::Sequential.new(
 )
 
 gate = MARS::Gate.new(
-  condition: ->(input) { input.split.length < 10 ? :success : :failure },
-  branches: {
+  check: ->(input) { :failure unless input.split.length < 10 },
+  fallbacks: {
     failure: error_workflow
   }
 )

--- a/examples/complex_workflow/generator.rb
+++ b/examples/complex_workflow/generator.rb
@@ -46,8 +46,8 @@ parallel_workflow2 = MARS::Workflows::Parallel.new(
 
 # Create the gate that decides between exit or continue
 gate = MARS::Gate.new(
-  condition: ->(input) { input[:result] },
-  branches: {
+  check: ->(input) { input[:result] },
+  fallbacks: {
     warning: sequential_workflow,
     error: parallel_workflow
   }

--- a/examples/simple_workflow/generator.rb
+++ b/examples/simple_workflow/generator.rb
@@ -26,8 +26,8 @@ success_workflow = MARS::Workflows::Sequential.new(
 
 # Create the gate that decides between exit or continue
 gate = MARS::Gate.new(
-  condition: ->(input) { input[:result] },
-  branches: {
+  check: ->(input) { input[:result] },
+  fallbacks: {
     success: success_workflow
   }
 )

--- a/lib/mars/gate.rb
+++ b/lib/mars/gate.rb
@@ -3,40 +3,47 @@
 module MARS
   class Gate < Runnable
     class << self
-      def condition(&block)
-        @condition_block = block
+      def check(&block)
+        @check_block = block
       end
 
-      attr_reader :condition_block
+      attr_reader :check_block
 
-      def branch(key, runnable)
-        branches_map[key] = runnable
+      def fallback(key, runnable)
+        fallbacks_map[key] = runnable
       end
 
-      def branches_map
-        @branches_map ||= {}
+      def fallbacks_map
+        @fallbacks_map ||= {}
+      end
+
+      def halt_scope(scope = nil)
+        scope ? @halt_scope = scope : @halt_scope
       end
     end
 
-    def initialize(name = "Gate", condition: nil, branches: nil, **kwargs)
+    def initialize(name = "Gate", check: nil, fallbacks: nil, halt_scope: nil, **kwargs)
       super(name: name, **kwargs)
 
-      @condition = condition || self.class.condition_block
-      @branches = branches || self.class.branches_map
+      @check = check || self.class.check_block
+      @fallbacks = fallbacks || self.class.fallbacks_map
+      @halt_scope = halt_scope || self.class.halt_scope || :local
     end
 
     def run(input)
-      result = condition.call(input)
-      branch = branches[result]
+      result = check.call(input)
 
-      return input unless branch
+      return input unless result
 
-      Halt.new(resolve_branch(branch).run(input))
+      branch = fallbacks[result]
+      raise ArgumentError, "No fallback registered for #{result.inspect}" unless branch
+
+      Halt.new(resolve_branch(branch).run(input), scope: @halt_scope)
     end
 
     private
 
-    attr_reader :condition, :branches
+    attr_reader :check, :fallbacks
 
     def resolve_branch(branch)
       branch.is_a?(Class) ? branch.new : branch

--- a/lib/mars/gate.rb
+++ b/lib/mars/gate.rb
@@ -2,21 +2,44 @@
 
 module MARS
   class Gate < Runnable
-    def initialize(name = "Gate", condition:, branches:, **kwargs)
+    class << self
+      def condition(&block)
+        @condition_block = block
+      end
+
+      attr_reader :condition_block
+
+      def branch(key, runnable)
+        branches_map[key] = runnable
+      end
+
+      def branches_map
+        @branches_map ||= {}
+      end
+    end
+
+    def initialize(name = "Gate", condition: nil, branches: nil, **kwargs)
       super(name: name, **kwargs)
 
-      @condition = condition
-      @branches = branches
+      @condition = condition || self.class.condition_block
+      @branches = branches || self.class.branches_map
     end
 
     def run(input)
       result = condition.call(input)
+      branch = branches[result]
 
-      branches[result] || input
+      return input unless branch
+
+      resolve_branch(branch).run(input)
     end
 
     private
 
     attr_reader :condition, :branches
+
+    def resolve_branch(branch)
+      branch.is_a?(Class) ? branch.new : branch
+    end
   end
 end

--- a/lib/mars/gate.rb
+++ b/lib/mars/gate.rb
@@ -31,7 +31,7 @@ module MARS
 
       return input unless branch
 
-      resolve_branch(branch).run(input)
+      Halt.new(resolve_branch(branch).run(input))
     end
 
     private

--- a/lib/mars/halt.rb
+++ b/lib/mars/halt.rb
@@ -1,0 +1,11 @@
+# frozen_string_literal: true
+
+module MARS
+  class Halt
+    attr_reader :result
+
+    def initialize(result)
+      @result = result
+    end
+  end
+end

--- a/lib/mars/halt.rb
+++ b/lib/mars/halt.rb
@@ -2,10 +2,14 @@
 
 module MARS
   class Halt
-    attr_reader :result
+    attr_reader :result, :scope
 
-    def initialize(result)
+    def initialize(result, scope: :local)
       @result = result
+      @scope = scope
     end
+
+    def local? = scope == :local
+    def global? = scope == :global
   end
 end

--- a/lib/mars/rendering/graph/gate.rb
+++ b/lib/mars/rendering/graph/gate.rb
@@ -10,8 +10,8 @@ module MARS
           builder.add_node(node_id, name, Node::GATE)
           builder.add_edge(parent_id, node_id, value)
 
-          sink_nodes = branches.map do |condition_result, branch|
-            branch.to_graph(builder, parent_id: node_id, value: condition_result)
+          sink_nodes = fallbacks.map do |fallback_key, branch|
+            branch.to_graph(builder, parent_id: node_id, value: fallback_key)
           end
 
           sink_nodes.flatten

--- a/lib/mars/workflows/parallel.rb
+++ b/lib/mars/workflows/parallel.rb
@@ -16,9 +16,10 @@ module MARS
 
         raise AggregateError, errors if errors.any?
 
-        has_halt = results.any?(Halt)
-        result = aggregator.run(results)
-        has_halt ? Halt.new(result) : result
+        has_global_halt = results.any? { |r| r.is_a?(Halt) && r.global? }
+        unwrapped = results.map { |r| r.is_a?(Halt) ? r.result : r }
+        result = aggregator.run(unwrapped)
+        has_global_halt ? Halt.new(result, scope: :global) : result
       end
 
       private

--- a/lib/mars/workflows/parallel.rb
+++ b/lib/mars/workflows/parallel.rb
@@ -26,7 +26,9 @@ module MARS
 
         raise AggregateError, errors if errors.any?
 
-        aggregator.run(results)
+        has_halt = results.any? { |r| r.is_a?(Halt) }
+        result = aggregator.run(results)
+        has_halt ? Halt.new(result) : result
       end
 
       private

--- a/lib/mars/workflows/parallel.rb
+++ b/lib/mars/workflows/parallel.rb
@@ -12,8 +12,22 @@ module MARS
 
       def run(input)
         errors = []
-        results = Async do |workflow|
-          tasks = @steps.map do |step|
+        results = execute_steps(input, errors)
+
+        raise AggregateError, errors if errors.any?
+
+        has_halt = results.any?(Halt)
+        result = aggregator.run(results)
+        has_halt ? Halt.new(result) : result
+      end
+
+      private
+
+      attr_reader :steps, :aggregator
+
+      def execute_steps(input, errors)
+        Async do |workflow|
+          tasks = steps.map do |step|
             workflow.async do
               step.run(input)
             rescue StandardError => e
@@ -23,17 +37,7 @@ module MARS
 
           tasks.map(&:wait)
         end.result
-
-        raise AggregateError, errors if errors.any?
-
-        has_halt = results.any? { |r| r.is_a?(Halt) }
-        result = aggregator.run(results)
-        has_halt ? Halt.new(result) : result
       end
-
-      private
-
-      attr_reader :steps, :aggregator
     end
   end
 end

--- a/lib/mars/workflows/sequential.rb
+++ b/lib/mars/workflows/sequential.rb
@@ -11,14 +11,7 @@ module MARS
 
       def run(input)
         @steps.each do |step|
-          result = step.run(input)
-
-          if result.is_a?(Runnable)
-            input = result.run(input)
-            break
-          else
-            input = result
-          end
+          input = step.run(input)
         end
 
         input

--- a/lib/mars/workflows/sequential.rb
+++ b/lib/mars/workflows/sequential.rb
@@ -12,6 +12,11 @@ module MARS
       def run(input)
         @steps.each do |step|
           input = step.run(input)
+
+          if input.is_a?(Halt)
+            input = input.result
+            break
+          end
         end
 
         input

--- a/lib/mars/workflows/sequential.rb
+++ b/lib/mars/workflows/sequential.rb
@@ -13,10 +13,12 @@ module MARS
         @steps.each do |step|
           input = step.run(input)
 
-          if input.is_a?(Halt)
-            input = input.result
-            break
-          end
+          next unless input.is_a?(Halt)
+
+          return input if input.global?
+
+          input = input.result
+          break
         end
 
         input

--- a/spec/mars/aggregator_spec.rb
+++ b/spec/mars/aggregator_spec.rb
@@ -2,7 +2,7 @@
 
 RSpec.describe MARS::Aggregator do
   describe "#run" do
-    context "when called without a block" do
+    context "when called without an operation" do
       let(:aggregator) { described_class.new }
 
       it "returns the input as is" do
@@ -11,10 +11,10 @@ RSpec.describe MARS::Aggregator do
       end
     end
 
-    context "when initialized with a block operation" do
+    context "when initialized with an operation" do
       let(:aggregator) { described_class.new("Aggregator", operation: lambda(&:join)) }
 
-      it "executes the block and returns its value" do
+      it "executes the operation and returns its value" do
         result = aggregator.run(%w[a b c])
         expect(result).to eq("abc")
       end

--- a/spec/mars/gate_spec.rb
+++ b/spec/mars/gate_spec.rb
@@ -27,12 +27,16 @@ RSpec.describe MARS::Gate do
         )
       end
 
-      it "executes the matched branch directly" do
-        expect(gate.run("hi")).to eq("short: hi")
+      it "returns a Halt wrapping the branch result" do
+        result = gate.run("hi")
+        expect(result).to be_a(MARS::Halt)
+        expect(result.result).to eq("short: hi")
       end
 
       it "executes the other branch for different input" do
-        expect(gate.run("longstring")).to eq("long: longstring")
+        result = gate.run("longstring")
+        expect(result).to be_a(MARS::Halt)
+        expect(result.result).to eq("long: longstring")
       end
 
       it "returns input when no branch matches" do
@@ -74,8 +78,8 @@ RSpec.describe MARS::Gate do
         end
 
         gate = gate_class.new("DSLGate")
-        expect(gate.run("hi")).to eq("quick: hi")
-        expect(gate.run("longstring")).to eq("deep: longstring")
+        expect(gate.run("hi").result).to eq("quick: hi")
+        expect(gate.run("longstring").result).to eq("deep: longstring")
       end
     end
 
@@ -107,15 +111,15 @@ RSpec.describe MARS::Gate do
       end
 
       it "routes to low branch" do
-        expect(gate.run(5)).to eq("low:5")
+        expect(gate.run(5).result).to eq("low:5")
       end
 
       it "routes to medium branch" do
-        expect(gate.run(25)).to eq("med:25")
+        expect(gate.run(25).result).to eq("med:25")
       end
 
       it "routes to high branch" do
-        expect(gate.run(100)).to eq("high:100")
+        expect(gate.run(100).result).to eq("high:100")
       end
     end
   end

--- a/spec/mars/gate_spec.rb
+++ b/spec/mars/gate_spec.rb
@@ -2,82 +2,120 @@
 
 RSpec.describe MARS::Gate do
   describe "#run" do
-    let(:gate) { described_class.new("TestGate", condition: condition, branches: branches) }
-
-    context "with simple boolean condition" do
-      let(:condition) { ->(input) { input > 5 } }
-      let(:false_branch) { instance_spy(MARS::Runnable) }
-      let(:branches) { { false => false_branch } }
-
-      it "returns the input when no branch matches" do
-        result = gate.run(10)
-        expect(result).to eq(10)
+    context "with constructor-based configuration" do
+      let(:short_step) do
+        Class.new(MARS::Runnable) do
+          def run(input)
+            "short: #{input}"
+          end
+        end.new
       end
 
-      it "returns the false branch when condition is false" do
-        result = gate.run(3)
-
-        expect(result).to eq(false_branch)
+      let(:long_step) do
+        Class.new(MARS::Runnable) do
+          def run(input)
+            "long: #{input}"
+          end
+        end.new
       end
 
-      it "does not run the false branch when condition is false" do
-        gate.run(3)
+      let(:gate) do
+        described_class.new(
+          "LengthGate",
+          condition: ->(input) { input.length > 5 ? :long : :short },
+          branches: { short: short_step, long: long_step }
+        )
+      end
 
-        expect(false_branch).not_to have_received(:run)
+      it "executes the matched branch directly" do
+        expect(gate.run("hi")).to eq("short: hi")
+      end
+
+      it "executes the other branch for different input" do
+        expect(gate.run("longstring")).to eq("long: longstring")
+      end
+
+      it "returns input when no branch matches" do
+        gate = described_class.new(
+          "NoMatch",
+          condition: ->(_input) { :unknown },
+          branches: { short: short_step }
+        )
+
+        expect(gate.run("hello")).to eq("hello")
       end
     end
 
-    context "with string-based condition" do
-      let(:condition) { ->(input) { input.length > 5 ? "long" : "short" } }
-      let(:long_branch) { instance_spy(MARS::Runnable) }
-      let(:short_branch) { instance_spy(MARS::Runnable) }
-      let(:branches) { { "long" => long_branch, "short" => short_branch } }
-
-      it "routes to long branch for long strings" do
-        result = gate.run("longstring")
-
-        expect(result).to eq(long_branch)
-      end
-
-      it "routes to short branch for short strings" do
-        result = gate.run("hi")
-
-        expect(result).to eq(short_branch)
-      end
-    end
-
-    context "with complex condition logic" do
-      let(:condition) do
-        lambda do |input|
-          case input
-          when 0..10 then "low"
-          when 11..50 then "medium"
-          else "high"
+    context "with class-level DSL" do
+      let(:short_step_class) do
+        Class.new(MARS::Runnable) do
+          def run(input)
+            "quick: #{input}"
           end
         end
       end
 
-      let(:low_branch) { instance_spy(MARS::Runnable) }
-      let(:medium_branch) { instance_spy(MARS::Runnable) }
-      let(:high_branch) { instance_spy(MARS::Runnable) }
-      let(:branches) { { "low" => low_branch, "medium" => medium_branch, "high" => high_branch } }
+      let(:long_step_class) do
+        Class.new(MARS::Runnable) do
+          def run(input)
+            "deep: #{input}"
+          end
+        end
+      end
+
+      it "uses condition and branch DSL" do
+        short_cls = short_step_class
+        long_cls = long_step_class
+
+        gate_class = Class.new(described_class) do
+          condition { |input| input.length < 5 ? :short : :long }
+          branch :short, short_cls
+          branch :long, long_cls
+        end
+
+        gate = gate_class.new("DSLGate")
+        expect(gate.run("hi")).to eq("quick: hi")
+        expect(gate.run("longstring")).to eq("deep: longstring")
+      end
+    end
+
+    context "with complex condition logic" do
+      let(:low_step) do
+        Class.new(MARS::Runnable) { def run(input) = "low:#{input}" }.new
+      end
+
+      let(:medium_step) do
+        Class.new(MARS::Runnable) { def run(input) = "med:#{input}" }.new
+      end
+
+      let(:high_step) do
+        Class.new(MARS::Runnable) { def run(input) = "high:#{input}" }.new
+      end
+
+      let(:gate) do
+        described_class.new(
+          "SeverityGate",
+          condition: lambda { |input|
+            case input
+            when 0..10 then :low
+            when 11..50 then :medium
+            else :high
+            end
+          },
+          branches: { low: low_step, medium: medium_step, high: high_step }
+        )
+      end
 
       it "routes to low branch" do
-        result = gate.run(5)
-
-        expect(result).to eq(low_branch)
+        expect(gate.run(5)).to eq("low:5")
       end
 
       it "routes to medium branch" do
-        result = gate.run(25)
-
-        expect(result).to eq(medium_branch)
+        expect(gate.run(25)).to eq("med:25")
       end
 
       it "routes to high branch" do
-        result = gate.run(100)
-
-        expect(result).to eq(high_branch)
+        expect(gate.run(100)).to eq("high:100")
       end
     end
   end

--- a/spec/mars/gate_spec.rb
+++ b/spec/mars/gate_spec.rb
@@ -1,125 +1,127 @@
 # frozen_string_literal: true
 
 RSpec.describe MARS::Gate do
+  let(:fallback_step) do
+    Class.new(MARS::Runnable) do
+      def run(input)
+        "fallback: #{input}"
+      end
+    end.new
+  end
+
+  let(:error_step) do
+    Class.new(MARS::Runnable) do
+      def run(input)
+        "error: #{input}"
+      end
+    end.new
+  end
+
   describe "#run" do
     context "with constructor-based configuration" do
-      let(:short_step) do
-        Class.new(MARS::Runnable) do
-          def run(input)
-            "short: #{input}"
-          end
-        end.new
-      end
-
-      let(:long_step) do
-        Class.new(MARS::Runnable) do
-          def run(input)
-            "long: #{input}"
-          end
-        end.new
-      end
-
-      let(:gate) do
-        described_class.new(
-          "LengthGate",
-          condition: ->(input) { input.length > 5 ? :long : :short },
-          branches: { short: short_step, long: long_step }
-        )
-      end
-
-      it "returns a Halt wrapping the branch result" do
-        result = gate.run("hi")
-        expect(result).to be_a(MARS::Halt)
-        expect(result.result).to eq("short: hi")
-      end
-
-      it "executes the other branch for different input" do
-        result = gate.run("longstring")
-        expect(result).to be_a(MARS::Halt)
-        expect(result.result).to eq("long: longstring")
-      end
-
-      it "returns input when no branch matches" do
+      it "passes through when check returns falsy" do
         gate = described_class.new(
-          "NoMatch",
-          condition: ->(_input) { :unknown },
-          branches: { short: short_step }
+          "PassGate",
+          check: ->(_input) {},
+          fallbacks: { fail: fallback_step }
         )
 
         expect(gate.run("hello")).to eq("hello")
       end
+
+      it "halts with fallback result when check returns a key" do
+        gate = described_class.new(
+          "FailGate",
+          check: ->(_input) { :fail },
+          fallbacks: { fail: fallback_step }
+        )
+
+        result = gate.run("hello")
+        expect(result).to be_a(MARS::Halt)
+        expect(result.result).to eq("fallback: hello")
+      end
+
+      it "raises when check returns an unregistered key" do
+        gate = described_class.new(
+          "BadGate",
+          check: ->(_input) { :unknown },
+          fallbacks: { fail: fallback_step }
+        )
+
+        expect { gate.run("hello") }.to raise_error(ArgumentError, /No fallback registered for :unknown/)
+      end
+
+      it "selects among multiple fallbacks" do
+        gate = described_class.new(
+          "MultiFallback",
+          check: ->(input) { input[:error_type] },
+          fallbacks: { timeout: fallback_step, auth: error_step }
+        )
+
+        input = { error_type: :auth }
+        result = gate.run(input)
+        expect(result).to be_a(MARS::Halt)
+        expect(result.result).to eq("error: #{input}")
+      end
     end
 
     context "with class-level DSL" do
-      let(:short_step_class) do
+      let(:fallback_cls) do
         Class.new(MARS::Runnable) do
           def run(input)
-            "quick: #{input}"
+            "handled: #{input}"
           end
         end
       end
 
-      let(:long_step_class) do
-        Class.new(MARS::Runnable) do
-          def run(input)
-            "deep: #{input}"
-          end
-        end
-      end
-
-      it "uses condition and branch DSL" do
-        short_cls = short_step_class
-        long_cls = long_step_class
-
+      it "uses check and fallback DSL" do
+        cls = fallback_cls
         gate_class = Class.new(described_class) do
-          condition { |input| input.length < 5 ? :short : :long }
-          branch :short, short_cls
-          branch :long, long_cls
+          check { |input| :invalid if input.length > 5 }
+          fallback :invalid, cls
         end
 
         gate = gate_class.new("DSLGate")
-        expect(gate.run("hi").result).to eq("quick: hi")
-        expect(gate.run("longstring").result).to eq("deep: longstring")
+        expect(gate.run("hi")).to eq("hi")
+        expect(gate.run("longstring").result).to eq("handled: longstring")
+      end
+
+      it "supports halt_scope DSL" do
+        cls = fallback_cls
+        gate_class = Class.new(described_class) do
+          check { |_input| :fail }
+          fallback :fail, cls
+          halt_scope :global
+        end
+
+        result = gate_class.new("GlobalGate").run("test")
+        expect(result).to be_a(MARS::Halt)
+        expect(result).to be_global
       end
     end
 
-    context "with complex condition logic" do
-      let(:low_step) do
-        Class.new(MARS::Runnable) { def run(input) = "low:#{input}" }.new
-      end
-
-      let(:medium_step) do
-        Class.new(MARS::Runnable) { def run(input) = "med:#{input}" }.new
-      end
-
-      let(:high_step) do
-        Class.new(MARS::Runnable) { def run(input) = "high:#{input}" }.new
-      end
-
-      let(:gate) do
-        described_class.new(
-          "SeverityGate",
-          condition: lambda { |input|
-            case input
-            when 0..10 then :low
-            when 11..50 then :medium
-            else :high
-            end
-          },
-          branches: { low: low_step, medium: medium_step, high: high_step }
+    context "with halt scope" do
+      it "defaults to local scope" do
+        gate = described_class.new(
+          "LocalGate",
+          check: ->(_input) { :fail },
+          fallbacks: { fail: fallback_step }
         )
+
+        result = gate.run("hello")
+        expect(result).to be_local
       end
 
-      it "routes to low branch" do
-        expect(gate.run(5).result).to eq("low:5")
-      end
+      it "respects constructor halt_scope" do
+        gate = described_class.new(
+          "GlobalGate",
+          check: ->(_input) { :fail },
+          fallbacks: { fail: fallback_step },
+          halt_scope: :global
+        )
 
-      it "routes to medium branch" do
-        expect(gate.run(25).result).to eq("med:25")
-      end
-
-      it "routes to high branch" do
-        expect(gate.run(100).result).to eq("high:100")
+        result = gate.run("hello")
+        expect(result).to be_global
       end
     end
   end

--- a/spec/mars/halt_spec.rb
+++ b/spec/mars/halt_spec.rb
@@ -1,0 +1,26 @@
+# frozen_string_literal: true
+
+RSpec.describe MARS::Halt do
+  describe "#scope" do
+    it "defaults to :local" do
+      halt = described_class.new("result")
+      expect(halt.scope).to eq(:local)
+      expect(halt).to be_local
+      expect(halt).not_to be_global
+    end
+
+    it "can be set to :global" do
+      halt = described_class.new("result", scope: :global)
+      expect(halt.scope).to eq(:global)
+      expect(halt).to be_global
+      expect(halt).not_to be_local
+    end
+  end
+
+  describe "#result" do
+    it "stores the result" do
+      halt = described_class.new("hello")
+      expect(halt.result).to eq("hello")
+    end
+  end
+end

--- a/spec/mars/workflows/parallel_spec.rb
+++ b/spec/mars/workflows/parallel_spec.rb
@@ -77,6 +77,27 @@ RSpec.describe MARS::Workflows::Parallel do
       expect(workflow.run(42)).to eq([])
     end
 
+    it "propagates Halt to parent workflow when a step halts" do
+      gate = MARS::Gate.new(
+        "AlwaysBranch",
+        condition: ->(_input) { :branch },
+        branches: {
+          branch: Class.new(MARS::Runnable) {
+            def run(input)
+              "branched:#{input}"
+            end
+          }.new
+        }
+      )
+      add_five = add_step_class.new(5)
+
+      workflow = described_class.new("halt_workflow", steps: [gate, add_five])
+
+      result = workflow.run(10)
+      # Aggregator runs on all results, but output is wrapped in Halt
+      expect(result).to be_a(MARS::Halt)
+    end
+
     it "propagates errors from steps" do
       add_step = add_step_class.new(5)
       error_step = error_step_class.new("Step failed", "error_step_one")

--- a/spec/mars/workflows/parallel_spec.rb
+++ b/spec/mars/workflows/parallel_spec.rb
@@ -77,11 +77,11 @@ RSpec.describe MARS::Workflows::Parallel do
       expect(workflow.run(42)).to eq([])
     end
 
-    it "propagates Halt to parent workflow when a step halts" do
+    it "unwraps local halts and returns plain result" do
       gate = MARS::Gate.new(
-        "AlwaysBranch",
-        condition: ->(_input) { :branch },
-        branches: {
+        "LocalBranch",
+        check: ->(_input) { :branch },
+        fallbacks: {
           branch: Class.new(MARS::Runnable) do
             def run(input)
               "branched:#{input}"
@@ -94,8 +94,32 @@ RSpec.describe MARS::Workflows::Parallel do
       workflow = described_class.new("halt_workflow", steps: [gate, add_five])
 
       result = workflow.run(10)
-      # Aggregator runs on all results, but output is wrapped in Halt
+      # Local halts are unwrapped, aggregated as plain values
+      expect(result).not_to be_a(MARS::Halt)
+      expect(result).to eq(["branched:10", 15])
+    end
+
+    it "propagates global halt to parent workflow" do
+      gate = MARS::Gate.new(
+        "GlobalBranch",
+        check: ->(_input) { :branch },
+        fallbacks: {
+          branch: Class.new(MARS::Runnable) do
+            def run(input)
+              "branched:#{input}"
+            end
+          end.new
+        },
+        halt_scope: :global
+      )
+      add_five = add_step_class.new(5)
+
+      workflow = described_class.new("halt_workflow", steps: [gate, add_five])
+
+      result = workflow.run(10)
       expect(result).to be_a(MARS::Halt)
+      expect(result).to be_global
+      expect(result.result).to eq(["branched:10", 15])
     end
 
     it "propagates errors from steps" do

--- a/spec/mars/workflows/parallel_spec.rb
+++ b/spec/mars/workflows/parallel_spec.rb
@@ -82,11 +82,11 @@ RSpec.describe MARS::Workflows::Parallel do
         "AlwaysBranch",
         condition: ->(_input) { :branch },
         branches: {
-          branch: Class.new(MARS::Runnable) {
+          branch: Class.new(MARS::Runnable) do
             def run(input)
               "branched:#{input}"
             end
-          }.new
+          end.new
         }
       )
       add_five = add_step_class.new(5)

--- a/spec/mars/workflows/sequential_spec.rb
+++ b/spec/mars/workflows/sequential_spec.rb
@@ -68,11 +68,11 @@ RSpec.describe MARS::Workflows::Sequential do
         "AlwaysBranch",
         condition: ->(_input) { :branch },
         branches: {
-          branch: Class.new(MARS::Runnable) {
+          branch: Class.new(MARS::Runnable) do
             def run(input)
               "branched:#{input}"
             end
-          }.new
+          end.new
         }
       )
       multiply_three = multiply_step_class.new(3)

--- a/spec/mars/workflows/sequential_spec.rb
+++ b/spec/mars/workflows/sequential_spec.rb
@@ -62,12 +62,12 @@ RSpec.describe MARS::Workflows::Sequential do
       expect(workflow.run(42)).to eq(42)
     end
 
-    it "halts when a step returns a Halt" do
+    it "halts locally when a gate triggers with local scope" do
       add_five = add_step_class.new(5)
       gate = MARS::Gate.new(
-        "AlwaysBranch",
-        condition: ->(_input) { :branch },
-        branches: {
+        "LocalGate",
+        check: ->(_input) { :branch },
+        fallbacks: {
           branch: Class.new(MARS::Runnable) do
             def run(input)
               "branched:#{input}"
@@ -80,7 +80,88 @@ RSpec.describe MARS::Workflows::Sequential do
       workflow = described_class.new("halt_workflow", steps: [add_five, gate, multiply_three])
 
       # 10 + 5 = 15, gate branches -> "branched:15", multiply_three is never reached
-      expect(workflow.run(10)).to eq("branched:15")
+      # Local halt is consumed — returns plain value
+      result = workflow.run(10)
+      expect(result).to eq("branched:15")
+      expect(result).not_to be_a(MARS::Halt)
+    end
+
+    it "propagates global halt without unwrapping" do
+      add_five = add_step_class.new(5)
+      gate = MARS::Gate.new(
+        "GlobalGate",
+        check: ->(_input) { :branch },
+        fallbacks: {
+          branch: Class.new(MARS::Runnable) do
+            def run(input)
+              "branched:#{input}"
+            end
+          end.new
+        },
+        halt_scope: :global
+      )
+      multiply_three = multiply_step_class.new(3)
+
+      workflow = described_class.new("halt_workflow", steps: [add_five, gate, multiply_three])
+
+      result = workflow.run(10)
+      expect(result).to be_a(MARS::Halt)
+      expect(result).to be_global
+      expect(result.result).to eq("branched:15")
+    end
+
+    it "propagates global halt through nested sequential workflows" do
+      inner_gate = MARS::Gate.new(
+        "InnerGate",
+        check: ->(_input) { :stop },
+        fallbacks: {
+          stop: Class.new(MARS::Runnable) do
+            def run(input)
+              "stopped:#{input}"
+            end
+          end.new
+        },
+        halt_scope: :global
+      )
+
+      inner = described_class.new("inner", steps: [inner_gate])
+      after_inner = add_step_class.new(100)
+      outer = described_class.new("outer", steps: [inner, after_inner])
+
+      result = outer.run(1)
+      # Global halt propagates through both sequential levels
+      expect(result).to be_a(MARS::Halt)
+      expect(result.result).to eq("stopped:1")
+    end
+
+    it "consumes local halt — outer workflow continues" do
+      inner_gate = MARS::Gate.new(
+        "InnerGate",
+        check: ->(_input) { :stop },
+        fallbacks: {
+          stop: Class.new(MARS::Runnable) do
+            def run(input)
+              "stopped:#{input}"
+            end
+          end.new
+        }
+        # default :local scope
+      )
+
+      inner = described_class.new("inner", steps: [inner_gate])
+
+      # Inner halts locally -> returns "stopped:1" as plain value
+      string_step = Class.new(MARS::Runnable) do
+        def run(input)
+          "after:#{input}"
+        end
+      end.new
+
+      outer = described_class.new("outer", steps: [inner, string_step])
+
+      result = outer.run(1)
+      expect(result).to eq("after:stopped:1")
+      expect(result).not_to be_a(MARS::Halt)
     end
 
     it "propagates errors from steps" do

--- a/spec/mars/workflows/sequential_spec.rb
+++ b/spec/mars/workflows/sequential_spec.rb
@@ -62,6 +62,27 @@ RSpec.describe MARS::Workflows::Sequential do
       expect(workflow.run(42)).to eq(42)
     end
 
+    it "halts when a step returns a Halt" do
+      add_five = add_step_class.new(5)
+      gate = MARS::Gate.new(
+        "AlwaysBranch",
+        condition: ->(_input) { :branch },
+        branches: {
+          branch: Class.new(MARS::Runnable) {
+            def run(input)
+              "branched:#{input}"
+            end
+          }.new
+        }
+      )
+      multiply_three = multiply_step_class.new(3)
+
+      workflow = described_class.new("halt_workflow", steps: [add_five, gate, multiply_three])
+
+      # 10 + 5 = 15, gate branches -> "branched:15", multiply_three is never reached
+      expect(workflow.run(10)).to eq("branched:15")
+    end
+
     it "propagates errors from steps" do
       add_step = add_step_class.new(5)
       error_step = error_step_class.new("Step failed")


### PR DESCRIPTION
## Summary
- **Gate redesigned as a guard**: replaces `condition`/`branch` router with `check`/`fallback` guard model. Check returns falsy to pass through, or a key to select a fallback branch and halt
- **Halt scopes**: `Halt` now carries a `scope` (`:local` default, `:global`). Local halts are consumed by the immediate parent workflow; global halts propagate to the root
- **Gate DSL**: `check`, `fallback`, and `halt_scope` class-level macros. Supports both DSL and constructor-based configuration
- **Sequential/Parallel updated**: respect halt scope — local halts are unwrapped, global halts propagate

## Test plan
- [x] Gate: pass-through on falsy check, halt on truthy check
- [x] Gate: multiple fallbacks selected by key
- [x] Gate: raises on unregistered fallback key
- [x] Gate DSL: `check`/`fallback`/`halt_scope` macros
- [x] Halt: default local scope, global scope, helper methods
- [x] Sequential: local halt consumed, global halt propagated
- [x] Sequential: nested workflows — local halt lets outer continue, global halts everything
- [x] Parallel: local halts unwrapped before aggregation, global halts propagated
- [x] 73 specs pass, 0 failures
- [x] Rubocop clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)